### PR TITLE
Add filename format shown in HamSCI Sunrisefest page as a part of allowed filename formats

### DIFF
--- a/sunrisefest_module.py
+++ b/sunrisefest_module.py
@@ -125,6 +125,11 @@ formats = [
         "name": "W2NAF",
         "human": "CALLSIGN_YYYY-MM-DDTHH_MM_SSZ_FREQUENCY_iq.wav",
         "re": r"(?P<callsign>[^_\n]+)_(?P<timestamp>\d{4}-\d{2}-\d{2}T\d{2}_\d{2}_\d{2}Z)_(?P<band>[\d.]+)_(?P<type>am|iq).wav"
+    },
+    {
+        "name": 'jj1bdx',
+        "human": "CALLSIGN_STATION_BAND_YYYY-MM-DD_HH-MM.wav",
+        "re": r"(?P<callsign>[^_]+)_(?P<station>[^_]+)_(?P<band>[^_]+)_(?P<timestamp>\d{4}-\d{2}-\d{2}_\d{2}-\d{2}).wav"
     }
 ]
 


### PR DESCRIPTION
The filename on the HamSCI Sunrisefest page at <https://hamsci.org/sunrisefest> is shown as `W8EDU_WWV_5MHz_2022-04-30_22-08.wav`, which is represented as `CALLSIGN_STATION_BAND_YYYY-MM-DD_HH-MM.wav` *without* IQ or AM in the filename. This format is *NOT* properly supported in the variable `formats` as an allowed filename format for submission to this festival.
The format 'jj1bdx' is added for the format represented above in the variable `formats` so that the filename withOUT IQ or AM is properly parsed.
You can change the format name, but I think this format should be supported because that's what I've seen on the Sunrisefest Web Page.