### PR TITLE
plot_signal(): Add dithering noise to prevent div0 error

### DIFF
--- a/sunrisefest_module.py
+++ b/sunrisefest_module.py
@@ -7,7 +7,7 @@ import plotly.graph_objects as go
 import scipy.signal
 from IPython.display import Audio, display
 import re
-
+import random
 
 def play(x, fs, autoplay=False):
     ''' Output an audio player that allows participants to listen to their wav files '''
@@ -39,10 +39,21 @@ def crosscorrelate(signal, template, fs):
     return Rxy, t
 
 def plot_signal(time_vec,x_0,xlim=None,title=None):
-    ''' Plot the signal in the time doman'''
+    ''' Plot the signal in the time domain'''
+
+    # This code add the very low level of white noise to the input
+    # so that the specgram will continue display on zero input values
+
+    minval = 1e-16
+    x_1 = x_0
+    for i in range(len(x_1)):
+      v = x_1[i]
+      if (v < 0) and (v > -minval):
+        x_1[i] = -minval * random.random()
+      elif (v >= 0) and (v < minval):
+        x_1[i] = minval * random.random()
     
     fig = plt.figure(figsize=(15,12))
-
     ax = fig.add_subplot(2,1,1)
     ax.plot(time_vec,x_0)
     ax.set_xticklabels([])
@@ -52,7 +63,8 @@ def plot_signal(time_vec,x_0,xlim=None,title=None):
 
     ax = fig.add_subplot(2,1,2)
     samplerate = 1./(time_vec[1]-time_vec[0])
-    ax.specgram(x_0,Fs=samplerate)
+    # display the noise-added spectrum data instead of the given data
+    ax.specgram(x_1,Fs=samplerate)
     ax.set_xlabel('Time [s]')
     ax.set_ylabel('Hz')
     ax.set_xlim(xlim)

--- a/sunrisefest_module.py
+++ b/sunrisefest_module.py
@@ -46,12 +46,15 @@ def plot_signal(time_vec,x_0,xlim=None,title=None):
 
     minval = 1e-16
     x_1 = x_0
+
     for i in range(len(x_1)):
+      # the random value must be greater than zero!
+      r = 1.0 - random.random() 
       v = x_1[i]
       if (v < 0) and (v > -minval):
-        x_1[i] = -minval * random.random()
+        x_1[i] = -minval * r
       elif (v >= 0) and (v < minval):
-        x_1[i] = minval * random.random()
+        x_1[i] = minval * r
     
     fig = plt.figure(figsize=(15,12))
     ax = fig.add_subplot(2,1,1)

--- a/sunrisefest_module.py
+++ b/sunrisefest_module.py
@@ -49,11 +49,12 @@ def plot_signal(time_vec,x_0,xlim=None,title=None):
 
     for i in range(len(x_1)):
       # the random value must be greater than zero!
-      r = 1.0 - random.random() 
       v = x_1[i]
       if (v < 0) and (v > -minval):
+        r = 1.0 - random.random() 
         x_1[i] = -minval * r
       elif (v >= 0) and (v < minval):
+        r = 1.0 - random.random() 
         x_1[i] = minval * r
     
     fig = plt.figure(figsize=(15,12))


### PR DESCRIPTION
This is a simple modification to add a very small level of random noise to display the spectrum to prevent division-by-zero error of matplotlib.pyplot.specgram and to show the low-level spectrum properly (not whitened).