### PR TITLE
fix yaml format in the papermill-example.py

### DIFF
--- a/papermill-example.py
+++ b/papermill-example.py
@@ -12,6 +12,7 @@ output_prefix = input_notebook.removesuffix('.ipynb')
 
 # Separate each target with triple dots (...)
 targets = """
+---
 # bogus data
 input_filename: w2naf.com_2021-11-15T19_07_36Z_10000.00_iq.wav
 input_requires_demodulation: True
@@ -19,9 +20,7 @@ lat: 12.34
 lon: -12.34
 radio: KX3
 antenna: tower-mounted beam
-
-...
-
+---
 # bogus data
 input_filename: N6GN_20211115T190749_iq_15.wav
 input_requires_demodulation: True
@@ -29,6 +28,7 @@ lat: 41.50
 lon: -81.61
 radio: ICOM 7600
 antenna: half-wave dipole
+...
 """
 
 


### PR DESCRIPTION
Fix the YAML document string content in papermill-example.py adhering to the standard as follows:

* YAML file format says:
  - Multiple documents are separated by three hyphens (—) in a single stream.
  - Hyphens indicate the start of the document.
  - Hyphens are also used to separate directives from document content.
  - The end of the document is indicated by three dots (…).
  - (See <https://docs.fileformat.com/programming/yaml/#syntax> for the details)